### PR TITLE
fix: correct frontpage date on Beitragsordnung

### DIFF
--- a/src/Beitragsordnung.tex
+++ b/src/Beitragsordnung.tex
@@ -37,7 +37,7 @@ urlcolor=p_petrol,
 
 \title{\textbf{Beitragsordnung}}
 \author{Plan b Chor Bonn e.V.}
-\date{16. April 2024}
+\date{19. Januar 2026}
 
 \newcounter{subparagraphCounter} % Zähler für Unterpunkte
 


### PR DESCRIPTION
Frontpage date was still showing 16. April 2024 instead of 19. Januar 2026.

Follow-up to #6.