### PR TITLE
fix: pre-create dist/ to avoid permission denied in FTP deploy

### DIFF
--- a/.github/workflows/deploy-antrag.yml
+++ b/.github/workflows/deploy-antrag.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Pull latex-compiler image
         run: docker pull ghcr.io/${{ github.repository_owner }}/latex-compiler:latest
 
+      - name: Create dist directory
+        run: mkdir -p dist
+
       - name: Build Mitgliedschaftsantrag.pdf
         run: |
           docker run --rm \


### PR DESCRIPTION
Fixes #13

## Summary
- Add a step to create `dist/` before Docker runs, so the directory is owned by the runner user
- Prevents FTP-Deploy-Action from failing with `EACCES: permission denied` when writing its sync state file

🤖 Generated with [Claude Code](https://claude.com/claude-code)