### PR TITLE
fix: correct exclude pattern syntax for FTP deploy

### DIFF
--- a/.github/workflows/deploy-antrag.yml
+++ b/.github/workflows/deploy-antrag.yml
@@ -72,4 +72,8 @@ jobs:
           protocol: ${{ secrets.ftp_protocol }}
           local-dir: ./dist/
           server-dir: ${{ vars.ftp_dest_dir }}
-          exclude: "**/*.aux|**/*.log|**/*.out"
+          exclude: |
+            **/*.aux
+            **/*.log
+            **/*.out
+            **/*.toc


### PR DESCRIPTION
Fixes #15

## Summary
- Replace pipe-separated exclude string with correct multiline glob array
- Also excludes `.toc` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)